### PR TITLE
Build Intel XPU community foundation

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/benchmarks-and-results.yml
+++ b/.github/DISCUSSION_TEMPLATE/benchmarks-and-results.yml
@@ -1,0 +1,70 @@
+title: "[Benchmark] "
+labels: ["benchmark"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Benchmarks should be reproducible. Include exact versions and commands.
+  - type: input
+    id: date
+    attributes:
+      label: Date
+      placeholder: "YYYY-MM-DD"
+    validations:
+      required: true
+  - type: input
+    id: hardware
+    attributes:
+      label: Hardware
+      placeholder: "GPU count/SKU, CPU, RAM, motherboard"
+    validations:
+      required: true
+  - type: textarea
+    id: software
+    attributes:
+      label: Software versions
+      description: "OS, kernel, driver, xpu-smi, oneAPI, framework, commit/package versions"
+      render: text
+    validations:
+      required: true
+  - type: input
+    id: model
+    attributes:
+      label: Model and quantization
+      placeholder: "Example: Qwen..., FP8 / Q4_0 / INT4 W4A16"
+    validations:
+      required: true
+  - type: textarea
+    id: command
+    attributes:
+      label: Command and environment
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: result
+    attributes:
+      label: Result
+      description: "Throughput, latency, context length, prompt/output tokens, batch/concurrency"
+      render: text
+    validations:
+      required: true
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation or quality check
+      placeholder: "How did you verify correctness or output quality?"
+    validations:
+      required: false
+  - type: dropdown
+    id: status
+    attributes:
+      label: Status
+      options:
+        - stable
+        - draft
+        - experimental
+        - negative
+        - suspect
+    validations:
+      required: true

--- a/.github/DISCUSSION_TEMPLATE/guides-and-patches.yml
+++ b/.github/DISCUSSION_TEMPLATE/guides-and-patches.yml
@@ -1,0 +1,46 @@
+title: "[Guide/Patch] "
+labels: ["guide", "patch"]
+body:
+  - type: input
+    id: area
+    attributes:
+      label: Area
+      placeholder: "Drivers, Docker, vLLM, llama.cpp, OpenVINO, PyTorch XPU, oneAPI"
+    validations:
+      required: true
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: "What does this guide or patch accomplish?"
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Tested environment
+      render: text
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps or patch commands
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: verification
+    attributes:
+      label: Verification
+      description: "Smoke tests, benchmark output, pass/fail evidence"
+      render: text
+    validations:
+      required: true
+  - type: textarea
+    id: risks
+    attributes:
+      label: Risks and limitations
+      placeholder: "What should people not assume?"
+    validations:
+      required: false

--- a/.github/DISCUSSION_TEMPLATE/research-links.yml
+++ b/.github/DISCUSSION_TEMPLATE/research-links.yml
@@ -1,0 +1,43 @@
+title: "[Research] "
+labels: ["research"]
+body:
+  - type: input
+    id: source
+    attributes:
+      label: Source link
+      placeholder: "Official docs, release notes, issue, PR, forum post, article"
+    validations:
+      required: true
+  - type: dropdown
+    id: confidence
+    attributes:
+      label: Confidence
+      options:
+        - official
+        - tested locally
+        - upstream issue or PR
+        - community report
+        - rumor
+    validations:
+      required: true
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: "What changed or what did you learn?"
+    validations:
+      required: true
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact for Intel XPU users
+      placeholder: "Drivers, runtime support, performance, compatibility, buying decisions"
+    validations:
+      required: false
+  - type: input
+    id: checked
+    attributes:
+      label: Date checked
+      placeholder: "YYYY-MM-DD"
+    validations:
+      required: true

--- a/.github/DISCUSSION_TEMPLATE/setup-help.yml
+++ b/.github/DISCUSSION_TEMPLATE/setup-help.yml
@@ -1,0 +1,57 @@
+title: "[Setup Help] "
+labels: ["setup", "help wanted"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Include enough detail for another person to find the failing layer.
+  - type: input
+    id: gpu
+    attributes:
+      label: GPU model and count
+      placeholder: "Example: 2x Intel Arc Pro B70"
+    validations:
+      required: true
+  - type: input
+    id: system
+    attributes:
+      label: System
+      placeholder: "CPU, motherboard, RAM, PSU, risers if any"
+    validations:
+      required: false
+  - type: input
+    id: os
+    attributes:
+      label: OS and kernel/build
+      placeholder: "Example: Ubuntu 24.04, kernel 6.x / Windows 11 24H2"
+    validations:
+      required: true
+  - type: textarea
+    id: versions
+    attributes:
+      label: Driver and runtime versions
+      description: "xpu-smi, Level Zero, OpenCL, oneAPI, PyTorch XPU, OpenVINO, framework versions"
+      render: text
+    validations:
+      required: true
+  - type: textarea
+    id: commands
+    attributes:
+      label: Commands run
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: output
+    attributes:
+      label: Output or error
+      render: text
+    validations:
+      required: true
+  - type: textarea
+    id: goal
+    attributes:
+      label: What are you trying to run?
+      placeholder: "Model, framework, deployment target, benchmark goal"
+    validations:
+      required: true

--- a/.github/DISCUSSION_TEMPLATE/show-and-tell.yml
+++ b/.github/DISCUSSION_TEMPLATE/show-and-tell.yml
@@ -1,0 +1,31 @@
+title: "[Show and Tell] "
+labels: ["show and tell"]
+body:
+  - type: input
+    id: build
+    attributes:
+      label: What did you build?
+      placeholder: "Example: dual B70 local inference box"
+    validations:
+      required: true
+  - type: textarea
+    id: hardware
+    attributes:
+      label: Hardware
+      render: text
+    validations:
+      required: false
+  - type: textarea
+    id: software
+    attributes:
+      label: Software stack
+      render: text
+    validations:
+      required: false
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      placeholder: "What works, what is surprising, what are you testing next?"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Setup help and community questions
+    url: https://github.com/steveseguin/Unofficial-Intel-XPU-Community/discussions
+    about: Please use Discussions for setup help, benchmark reports, research links, and general questions.
+  - name: Research lab
+    url: https://github.com/steveseguin/b70-optimization-lab
+    about: Fast-moving AI-assisted research logs, benchmark payloads, and experimental patches live here.

--- a/.github/ISSUE_TEMPLATE/docs-fix.yml
+++ b/.github/ISSUE_TEMPLATE/docs-fix.yml
@@ -1,0 +1,31 @@
+name: Docs fix
+description: Report a correction needed in the community docs or wiki drafts.
+title: "[Docs] "
+labels: ["documentation"]
+body:
+  - type: input
+    id: page
+    attributes:
+      label: Page or file
+      placeholder: "Example: docs/wiki/Drivers-and-Runtimes.md"
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What is wrong or outdated?
+    validations:
+      required: true
+  - type: textarea
+    id: correction
+    attributes:
+      label: Suggested correction
+    validations:
+      required: false
+  - type: input
+    id: source
+    attributes:
+      label: Source link
+      placeholder: "Official docs or reproducible test result"
+    validations:
+      required: false

--- a/COMMUNITY.md
+++ b/COMMUNITY.md
@@ -1,0 +1,31 @@
+# Community
+
+This community is for people building, testing, and documenting Intel XPU systems, especially Intel Arc Pro B-series cards.
+
+## What Belongs Here
+
+- setup notes that another person can follow
+- driver, firmware, BIOS, PCIe, and runtime troubleshooting
+- benchmark results with hardware, software, command, and model details
+- patches and build recipes for open source projects
+- links to upstream issues, release notes, and research
+- negative results that save other people time
+
+## What Makes A Useful Post
+
+Include enough detail for someone else to reproduce or falsify your result:
+
+- GPU model and count
+- motherboard, CPU, RAM, power supply, and riser information if relevant
+- operating system, kernel, BIOS settings, and Secure Boot state
+- driver package versions
+- oneAPI, Level Zero, OpenCL, PyTorch, OpenVINO, vLLM, llama.cpp, or other runtime versions
+- exact command line and environment variables
+- model name, quantization, context length, batch size, prompt/output lengths
+- benchmark output, validation checks, failures, and logs
+
+## Expectations
+
+Be specific, label speculation, and separate confirmed results from guesses. It is fine to be wrong; it is not useful to hide the evidence.
+
+Do not post API keys, private model files, license-restricted content, or vendor text copied in full. Link to sources instead.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# Contributing
+
+This repo is meant to turn scattered Intel XPU experiments into reproducible community knowledge.
+
+## Contribution Types
+
+- **Guide**: a setup, build, Docker, benchmark, or troubleshooting process that another person can run.
+- **Benchmark**: a result with enough metadata to compare against other systems.
+- **Patch note**: a focused explanation of a local patch, why it exists, how to apply it, and whether it is safe.
+- **Research note**: a sourced observation, release note, upstream issue, rumor, or compatibility update.
+- **Negative result**: a tested path that did not work, including what failed and what to avoid.
+
+## Promotion Rule
+
+Use [`steveseguin/b70-optimization-lab`](https://github.com/steveseguin/b70-optimization-lab) for raw, fast-moving experiments. Promote material here when it has:
+
+1. a clear environment
+2. exact commands or patch references
+3. a pass/fail result
+4. enough context for someone else to repeat it
+5. a clear status: stable, draft, experimental, negative, or rumor
+
+## Benchmark Minimums
+
+Every benchmark should include:
+
+- date
+- GPU model and count
+- OS and kernel
+- driver/runtime versions
+- framework and commit or package version
+- model and quantization
+- command line and environment variables
+- prompt length, output length, context length, batch/concurrency
+- throughput and latency numbers
+- validation method, if any
+
+Use [`templates/benchmark-result.md`](templates/benchmark-result.md) or the JSON schema in [`schemas/benchmark-result.schema.json`](schemas/benchmark-result.schema.json).
+
+## Safety
+
+Avoid publishing commands that blindly overwrite system files, disable security features, or install unsigned packages without explaining the risk. Prefer diagnostic commands first.
+
+Do not commit secrets, private model paths, API keys, SSH keys, or account tokens.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,77 @@
-# Unofficial-Intel-XPU-Community
-learnings, optimizations, metrics, community, discussions around the Intel Arc B70 and others
+# Unofficial Intel XPU Community
+
+Community notes, setup guides, benchmarks, patches, and discussion space for Intel Arc Pro B-series GPUs, Intel XPU runtimes, oneAPI, OpenVINO, PyTorch XPU, SYCL, Level Zero, vLLM, llama.cpp, and related tools.
+
+This is an unofficial community project. It is not owned by Intel. Treat everything here as community research unless it links to official vendor documentation.
+
+## Why This Exists
+
+Intel Arc Pro B-series cards, especially the Arc Pro B70, are interesting for local AI because they combine large VRAM, modern media engines, and Intel's XPU software stack. The public information is scattered across Intel docs, driver release notes, GitHub issues, benchmark posts, X threads, and local experiments.
+
+This repository is meant to become the stable, community-facing hub:
+
+- reproducible setup guides for Windows and Linux
+- Docker and container notes that other people can actually run
+- benchmark templates and results that can be compared
+- patch notes for vLLM, llama.cpp, OpenVINO, oneAPI, and SYCL work
+- troubleshooting guides for drivers, PCIe topology, XPU visibility, and runtime mismatches
+- Discussion categories for setup help, benchmarks, guides, patches, and research leads
+
+## Start Here
+
+- [Wiki home draft](docs/wiki/Home.md)
+- [Getting started](docs/wiki/Getting-Started.md)
+- [Two B70 use cases](docs/wiki/Two-B70-Use-Cases.md)
+- [Drivers and runtimes](docs/wiki/Drivers-and-Runtimes.md)
+- [Diagnostics](docs/wiki/Diagnostics.md)
+- [Benchmarks and results](docs/wiki/Benchmarks-and-Results.md)
+- [Docker and containers](docs/wiki/Docker-and-Containers.md)
+- [Research pipeline](docs/wiki/Research-Pipeline.md)
+- [Current research snapshot](docs/research/intel-xpu-b70-snapshot-2026-05-23.md)
+- [GitHub Wiki and Discussions setup](docs/guides/github-wiki-and-discussions-setup.md)
+
+## Current Working Model
+
+Use this repo for stable community material. Use [`steveseguin/b70-optimization-lab`](https://github.com/steveseguin/b70-optimization-lab) as the fast-moving research feed.
+
+The intended flow is:
+
+1. Experiment in the lab repo.
+2. Promote a result here only when it has enough detail for another person to reproduce.
+3. Capture the hardware, driver, runtime, command line, model, and validation evidence.
+4. Mark anything speculative, negative, or unsafe as such.
+
+## Good First Contributions
+
+- Post your B70 or other Intel XPU system in Discussions using the setup form.
+- Run the snapshot script in [`scripts/`](scripts/) and attach the output to a setup discussion.
+- Convert a lab note into a short, reproducible guide.
+- Add a benchmark result with the template in [`templates/benchmark-result.md`](templates/benchmark-result.md).
+- Link useful upstream issues, PRs, release notes, and forum threads.
+
+## For Two B70 Owners
+
+The best practical use case for two B70s depends on software support:
+
+- run two independent 32 GB GPU workloads when you want reliability and simple scheduling
+- run tensor parallel inference when the framework supports XPU communication cleanly
+- split services, for example one GPU for an LLM and the other for embeddings, vision, transcription, video, or test builds
+- benchmark scaling, driver versions, oneCCL settings, and model layouts
+
+Two cards do not automatically behave like one 64 GB GPU. Treat multi-GPU memory as software-managed unless a specific framework path proves otherwise.
+
+## Can An AI Configure This From The CLI?
+
+An AI agent can help a lot from the CLI: inventory hardware, install packages, generate Docker files, run diagnostics, collect logs, write systemd units, benchmark repeatably, and convert the results into documentation.
+
+Human approval is still needed for physical hardware, BIOS settings, slot layout, power, reboots, kernel changes, package trust, and anything run as root. The safe pattern is: collect a read-only snapshot first, then make one controlled change at a time, then benchmark.
+
+## Community Links
+
+- Discussions: https://github.com/steveseguin/Unofficial-Intel-XPU-Community/discussions
+- Research lab: https://github.com/steveseguin/b70-optimization-lab
+- Steve on X: https://x.com/xyster
+
+## License
+
+This repository is currently published under CC0. Contributions should be suitable for public reuse and should not include private tokens, proprietary model weights, private benchmark data, or copied vendor text beyond short quotes and links.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This repository is meant to become the stable, community-facing hub:
 - [Research pipeline](docs/wiki/Research-Pipeline.md)
 - [Current research snapshot](docs/research/intel-xpu-b70-snapshot-2026-05-23.md)
 - [GitHub Wiki and Discussions setup](docs/guides/github-wiki-and-discussions-setup.md)
+- [Lab to deployment roadmap](docs/roadmap/lab-to-deployment-roadmap.md)
 
 ## Current Working Model
 

--- a/community/discussion-categories.md
+++ b/community/discussion-categories.md
@@ -1,0 +1,31 @@
+# Suggested Discussion Categories
+
+Create these categories in GitHub Discussions, then use the matching forms in `.github/DISCUSSION_TEMPLATE/`. GitHub requires each form filename to match the category slug, as documented in [GitHub's discussion category forms docs](https://docs.github.com/discussions/managing-discussions-for-your-community/syntax-for-discussion-category-forms).
+
+## Announcements
+
+Maintainer updates, release notes, and major wiki changes.
+
+## Setup Help
+
+Driver, OS, BIOS, runtime, xpu-smi, Level Zero, OpenCL, PyTorch XPU, OpenVINO, and framework setup issues.
+
+## Benchmarks And Results
+
+Structured benchmark reports, scaling comparisons, and negative results.
+
+## Guides And Patches
+
+Reproducible guides, patch summaries, build notes, Docker recipes, and tested fixes.
+
+## Research Links
+
+Useful external sources: release notes, upstream issues, PRs, forum threads, articles, and rumors clearly marked as rumors.
+
+## Show And Tell
+
+Build photos, system descriptions, "what I am running", and informal progress updates.
+
+## Q&A
+
+Short questions that do not need a full setup report.

--- a/community/discussions-welcome.md
+++ b/community/discussions-welcome.md
@@ -1,0 +1,30 @@
+# Welcome To The Unofficial Intel XPU Community
+
+This is a place for Intel Arc Pro B70 and broader Intel XPU builders to compare notes, solve setup problems, and turn experiments into reproducible guides.
+
+Please use Discussions for:
+
+- setup help
+- driver and runtime troubleshooting
+- benchmark results
+- Docker and deployment notes
+- patches and build guides
+- links to useful Intel, OpenVINO, oneAPI, vLLM, llama.cpp, PyTorch XPU, and Level Zero work
+- negative results that save others time
+
+When introducing yourself, include:
+
+- what Intel GPU or XPU hardware you have
+- your OS and main workload
+- what you want to build
+- what is working
+- what is blocked
+
+If you are asking for help, please include command output as text where possible. Hardware and runtime details matter a lot with this stack.
+
+Useful starting links:
+
+- Wiki draft: `docs/wiki/Home.md`
+- Diagnostics scripts: `scripts/`
+- Benchmark template: `templates/benchmark-result.md`
+- Research lab: https://github.com/steveseguin/b70-optimization-lab

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,28 @@
+# Docker
+
+This directory is for tested Intel XPU container recipes.
+
+The first community goal is to produce a minimal, reproducible set of containers for:
+
+- PyTorch XPU smoke test
+- OpenVINO device query and sample inference
+- vLLM XPU smoke test
+- llama.cpp SYCL build and small-model smoke test
+
+## Required Metadata For Each Recipe
+
+Each container guide should include:
+
+- host OS and kernel
+- host Intel GPU driver/runtime packages
+- Docker or Podman version
+- required device mounts
+- required groups and permissions
+- base image and digest
+- exact run command
+- smoke test command
+- known failures
+
+## Do Not Add Yet
+
+Avoid adding a Dockerfile that only works on one private machine unless it is clearly labeled as experimental and includes host requirements.

--- a/docs/guides/ai-assisted-cli-setup.md
+++ b/docs/guides/ai-assisted-cli-setup.md
@@ -1,0 +1,57 @@
+# AI-Assisted CLI Setup
+
+An AI agent can help configure an Intel XPU system, but it should work in stages.
+
+## What An AI Can Do Well
+
+- collect hardware and software inventory
+- compare installed packages against official docs
+- generate install commands for the chosen OS
+- create Dockerfiles and compose files
+- run smoke tests
+- collect logs
+- generate benchmark matrices
+- summarize failures into Discussion posts
+- turn working commands into repo docs
+
+## What Needs Human Control
+
+- physical GPU placement
+- power cabling
+- BIOS updates and BIOS settings
+- accepting package trust changes
+- installing kernel modules
+- rebooting
+- disabling Secure Boot or security settings
+- changing production services
+- running unknown commands as administrator/root
+
+## Recommended Agent Flow
+
+1. Run the read-only snapshot script.
+2. Identify the first broken layer.
+3. Propose one change.
+4. Show the exact command.
+5. Run it only after approval if it uses root/admin privileges.
+6. Re-run the smoke test.
+7. Record the before/after result.
+
+## Good First Prompt
+
+```text
+You are helping configure an Intel Arc Pro B70 XPU machine.
+First collect a read-only hardware/software snapshot.
+Do not install packages or use sudo/admin until you show the exact command and explain why.
+After each change, run a small smoke test and record the result.
+The goal is a reproducible setup guide for the Unofficial Intel XPU Community repo.
+```
+
+## Useful Smoke Tests
+
+- PCIe inventory
+- `xpu-smi discovery`
+- `ze_info`
+- `clinfo`
+- PyTorch XPU device count
+- OpenVINO available devices
+- one small framework inference

--- a/docs/guides/github-wiki-and-discussions-setup.md
+++ b/docs/guides/github-wiki-and-discussions-setup.md
@@ -1,0 +1,55 @@
+# GitHub Wiki And Discussions Setup
+
+This repo includes source files for both the repository docs and the GitHub Wiki.
+
+## Discussions
+
+Suggested categories:
+
+- Announcements
+- Setup Help
+- Benchmarks And Results
+- Guides And Patches
+- Research Links
+- Show And Tell
+- Q&A
+
+GitHub category forms are stored in `.github/DISCUSSION_TEMPLATE/`. The filename must match the category slug:
+
+- `setup-help.yml`
+- `benchmarks-and-results.yml`
+- `guides-and-patches.yml`
+- `research-links.yml`
+- `show-and-tell.yml`
+
+After creating the categories in the GitHub UI, merge these files into the default branch. GitHub will then show the matching form when someone starts a discussion in that category.
+
+## Pinned Welcome Post
+
+Use [`community/discussions-welcome.md`](../../community/discussions-welcome.md) as the first pinned welcome discussion.
+
+## Wiki
+
+The wiki source pages live in `docs/wiki/`:
+
+- `Home.md`
+- `Getting-Started.md`
+- `Two-B70-Use-Cases.md`
+- `Drivers-and-Runtimes.md`
+- `Diagnostics.md`
+- `Benchmarks-and-Results.md`
+- `Docker-and-Containers.md`
+- `Research-Pipeline.md`
+
+If GitHub has already initialized the wiki repository:
+
+```bash
+git clone https://github.com/steveseguin/Unofficial-Intel-XPU-Community.wiki.git
+cp docs/wiki/*.md Unofficial-Intel-XPU-Community.wiki/
+cd Unofficial-Intel-XPU-Community.wiki
+git add -A
+git commit -m "Initialize Intel XPU community wiki"
+git push
+```
+
+If `git clone` returns `Repository not found` even though the Wiki feature is enabled, create the first `Home` page once through the GitHub Wiki UI, then repeat the clone/push flow.

--- a/docs/research/intel-xpu-b70-snapshot-2026-05-23.md
+++ b/docs/research/intel-xpu-b70-snapshot-2026-05-23.md
@@ -1,0 +1,107 @@
+# Intel XPU / B70 Research Snapshot
+
+Last checked: 2026-05-23.
+
+This page is a dated snapshot. Driver versions, package names, and hardware availability can change quickly.
+
+## Intel Arc Pro B70
+
+The Intel Arc Pro B70 is a professional Battlemage-generation GPU with 32 GB GDDR6 and XPU software support. Intel's product page lists:
+
+- 32 GB GDDR6 memory
+- PCIe 5.0 x16 interface
+- 224 XMX engines
+- AV1, HEVC, H.264, and VP9 media support
+- DirectX 12 Ultimate, OpenCL 3.0, Vulkan 1.3, oneAPI, and OpenVINO support
+
+Source: [Intel Arc Pro B70 specifications](https://www.intel.com/content/www/us/en/products/sku/245797/intel-arc-pro-b70-graphics/specifications.html)
+
+## Related Intel Arc Pro B-Series Cards
+
+Intel's B-series workstation lineup also includes other Arc Pro cards. The exact best choice depends on VRAM, slot/power constraints, display needs, and framework support.
+
+Track official Intel pages first:
+
+- [Intel Arc Pro B70](https://www.intel.com/content/www/us/en/products/sku/245797/intel-arc-pro-b70-graphics/specifications.html)
+- [Intel Arc Pro B-Series overview](https://www.intel.com/content/www/us/en/products/docs/discrete-gpus/arc/workstations/b-series/overview.html)
+- [Intel Arc Pro B60 datasheet](https://www.intel.com/content/dam/www/central-libraries/us/en/documents/2026-03/datasheet-b60-gpu.pdf)
+- [Intel Arc Pro B50 specifications](https://www.intel.com/content/www/us/en/products/sku/242615/intel-arc-pro-b50-graphics/specifications.html)
+- [Intel Pro Day 2026 newsroom post](https://newsroom.intel.com/client-computing/intel-core-ultra-series-3-with-vpro-powers-next-gen-pcs-on-18a)
+
+The 2026 Intel newsroom post says the Intel-branded Arc Pro B70 was available starting 2026-03-25, with Arc Pro B65 availability through AIB partners starting in mid-April 2026. Community posts should cite the exact Intel page and date checked because retailer listings and pre-release articles can drift.
+
+## Drivers And Runtime Stack
+
+For Windows, start from Intel's official support/download pages for the exact GPU and OS. At the time of this snapshot, Intel's current graphics download listing showed Arc B-series driver packages in the 32.0.101.8xxx range, but the download page changes frequently. Link the exact release notes when posting a driver-specific result.
+
+- [Intel Arc Pro B70 support](https://www.intel.com/content/www/us/en/support/products/245797/graphics/intel-arc-pro-dedicated-graphics-family/intel-arc-pro-b-series-graphics/intel-arc-pro-b70-graphics.html)
+- [Intel Graphics - Windows DCH drivers](https://www.intel.com/content/www/us/en/download/785597/intel-arc-iris-xe-graphics-windows.html)
+- [Intel Arc graphics drivers overview](https://www.intel.com/content/www/us/en/products/docs/discrete-gpus/arc/software/drivers.html)
+
+For Linux, the current public path is Intel's discrete GPU documentation plus distro packages. Use the distro and release that the docs explicitly support.
+
+- [Intel GPU documentation](https://dgpu-docs.intel.com/)
+- [Intel GPU software releases](https://dgpu-docs.intel.com/releases/index.html)
+- [Intel Client GPU packages for Linux](https://dgpu-docs.intel.com/driver/client/overview.html)
+
+For developer runtimes:
+
+- [Intel oneAPI Base Toolkit](https://www.intel.com/content/www/us/en/developer/tools/oneapi/base-toolkit.html)
+- [Intel oneAPI DPC++/C++ Compiler](https://www.intel.com/content/www/us/en/developer/tools/oneapi/dpc-compiler.html)
+- [Intel Extension for PyTorch](https://github.com/intel/intel-extension-for-pytorch)
+- [PyTorch XPU notes](https://pytorch.org/docs/stable/notes/get_start_xpu.html)
+- [OpenVINO](https://docs.openvino.ai/)
+- [Intel GPU Tools and xpu-smi](https://github.com/intel/xpumanager)
+
+## Frameworks Worth Tracking
+
+- vLLM XPU backend
+- llama.cpp SYCL backend
+- OpenVINO GenAI
+- Intel Extension for PyTorch
+- oneCCL and XCCL communication behavior
+- Level Zero tooling and topology reporting
+- Intel AI Containers and any XPU-ready container images
+
+## Two B70 Systems
+
+Two B70s are useful, but only some software paths can treat them as one coordinated inference device.
+
+Good early targets:
+
+- two independent model servers, one per GPU
+- one LLM plus one embedding, vision, transcription, or media pipeline
+- vLLM or PyTorch XPU tensor parallel tests
+- llama.cpp SYCL tensor split tests
+- OpenVINO model serving and media pipeline experiments
+- driver/runtime comparison work
+
+Avoid assuming automatic 64 GB pooling. Most frameworks need explicit tensor, pipeline, layer, or service-level partitioning.
+
+## Community And Forum Leads
+
+Places worth watching and linking from Discussions:
+
+- [Intel Community - Graphics](https://community.intel.com/t5/Graphics/bd-p/graphics)
+- [Intel Community - oneAPI](https://community.intel.com/t5/Intel-oneAPI-Toolkits/bd-p/oneapi)
+- [Intel GPU docs GitHub](https://github.com/intel-gpu/documentation)
+- [Intel Extension for PyTorch issues](https://github.com/intel/intel-extension-for-pytorch/issues)
+- [vLLM issues tagged XPU](https://github.com/vllm-project/vllm/issues?q=xpu)
+- [llama.cpp SYCL discussions/issues](https://github.com/ggml-org/llama.cpp/issues?q=sycl)
+- [OpenVINO discussions](https://github.com/openvinotoolkit/openvino/discussions)
+- [r/IntelArc](https://www.reddit.com/r/IntelArc/)
+- [Level1Techs forum search for Intel Arc Pro](https://forum.level1techs.com/search?q=Intel%20Arc%20Pro)
+
+## Upcoming GPU Rumors
+
+Keep rumors separate from confirmed support.
+
+As of this snapshot, public rumor coverage discusses Intel Xe3/Celestial and future Arc discrete GPU possibilities, but this repo should not treat unannounced SKUs, prices, VRAM sizes, or launch dates as facts. Use a "Rumor" label, link the source, and include the date checked.
+
+Useful search patterns:
+
+- `Intel Xe3 Celestial discrete GPU rumor`
+- `Intel Arc B770 rumor`
+- `Intel Arc Pro Battlemage future workstation GPU`
+
+Confirmed docs should always win over rumor posts.

--- a/docs/roadmap/lab-to-deployment-roadmap.md
+++ b/docs/roadmap/lab-to-deployment-roadmap.md
@@ -1,0 +1,104 @@
+# Lab To Deployment Roadmap
+
+This roadmap turns [`b70-optimization-lab`](https://github.com/steveseguin/b70-optimization-lab) from a fast research feed into deployable community guides, Docker recipes, patches, and benchmark reports.
+
+## Goal
+
+Keep the lab repo free to move quickly, but promote stable findings here in a format that other B70/XPU users can reproduce.
+
+## Phase 1: Curate Current Lab Results
+
+Create one short promotion candidate for each major result:
+
+- B70 PCIe topology and `xpu-smi` setup
+- Windows and Linux driver notes
+- single-GPU smoke tests
+- two-GPU service split recipes
+- three/four-GPU benchmark findings from the quad B70 build
+- llama.cpp SYCL Qwen results
+- vLLM XPU FP8 and INT4 results
+- MiniMax AutoRound work
+- negative oneCCL, graph, router, and helper experiments that should not be retried blindly
+
+Each promotion candidate should answer:
+
+- What exact hardware was used?
+- What exact software was used?
+- What command was run?
+- What passed?
+- What failed?
+- What is safe for others to copy?
+- What remains experimental?
+
+## Phase 2: Convert To Reproducible Guides
+
+For each promoted result, create:
+
+- a short guide in `docs/guides/`
+- a benchmark result in `templates/benchmark-result.md` format
+- a patch summary if local patches were required
+- a Discussion post asking for reproduction
+
+Prioritize guides that help new users get unstuck:
+
+1. install and verify drivers
+2. run the snapshot scripts
+3. verify PyTorch XPU
+4. verify OpenVINO
+5. run one small llama.cpp SYCL model
+6. run one small vLLM XPU model
+7. scale to two B70s
+
+## Phase 3: Add Deployment Recipes
+
+Deployment docs should be boring and repeatable.
+
+Target recipes:
+
+- one B70, one model server
+- two B70s, two independent model servers
+- two B70s, tensor-parallel vLLM smoke test
+- OpenVINO model server smoke test
+- llama.cpp SYCL server smoke test
+- Docker or Podman recipe for each working path
+- optional systemd unit files after the manual command is proven
+
+Each deployment recipe must include a rollback path and a minimal health check.
+
+## Phase 4: Benchmark And Patch Registry
+
+Add structured registries once there are enough entries:
+
+- `benchmarks/` for curated result JSON files
+- `patches/` for community patch summaries or links
+- `docker/` for tested container recipes
+- `configs/` for framework configs that are safe to reuse
+
+Do not copy large model files, generated caches, private paths, or secrets into this repo.
+
+## Phase 5: Automation
+
+Useful automation targets:
+
+- validate benchmark JSON against the schema
+- check Markdown links
+- check Discussion form YAML
+- generate a benchmark index from JSON files
+- generate a "latest promoted results" page from structured metadata
+
+## Promotion Labels
+
+Use these labels consistently:
+
+- `stable`: repeatable and recommended
+- `draft`: useful but needs another reproduction
+- `experimental`: patch-heavy or risky
+- `negative`: tested and not recommended
+- `suspect`: speed or behavior observed, correctness uncertain
+- `rumor`: external claim not confirmed by official docs or local testing
+
+## First Three Community Calls
+
+1. "Post your B70/XPU setup snapshot."
+2. "Reproduce the simplest PyTorch XPU/OpenVINO smoke tests."
+3. "Help turn one lab benchmark into a clean guide."

--- a/docs/wiki/Benchmarks-and-Results.md
+++ b/docs/wiki/Benchmarks-and-Results.md
@@ -1,0 +1,47 @@
+# Benchmarks And Results
+
+Benchmarks are useful only when they can be compared.
+
+## Required Metadata
+
+- date
+- GPU SKU and count
+- OS and kernel
+- driver/runtime versions
+- framework and commit or package version
+- model and quantization
+- context length
+- prompt tokens and output tokens
+- batch size or concurrency
+- exact command
+- environment variables
+- throughput and latency
+- validation or quality check
+- power limits or thermal constraints if changed
+
+Use [`templates/benchmark-result.md`](../../templates/benchmark-result.md).
+
+## Result Status Labels
+
+- **stable**: repeated, validated, and recommended
+- **draft**: likely useful but needs another reproduction
+- **experimental**: interesting but risky or patch-heavy
+- **negative**: tested and did not improve
+- **suspect**: reproduced a speed result but quality/correctness is uncertain
+- **rumor**: not confirmed by official docs or direct testing
+
+## Good Benchmark Posts
+
+Good posts include:
+
+- command output as text
+- logs or linked gist
+- model source and quantization
+- exact framework version
+- whether this was cold or warm
+- whether the result is one run or a mean
+- validation method
+
+## Negative Results Are Welcome
+
+If a knob regressed performance, caused a crash, changed output quality, or was impossible to reproduce, post it. Negative results are often the most valuable part of early hardware work.

--- a/docs/wiki/Diagnostics.md
+++ b/docs/wiki/Diagnostics.md
@@ -1,0 +1,50 @@
+# Diagnostics
+
+Diagnostics should be repeatable, read-only where possible, and easy to paste into a Discussion.
+
+## Snapshot Scripts
+
+- Linux: [`scripts/collect_xpu_snapshot.sh`](../../scripts/collect_xpu_snapshot.sh)
+- Windows: [`scripts/collect_xpu_snapshot.ps1`](../../scripts/collect_xpu_snapshot.ps1)
+
+The scripts collect command output into a local `xpu-snapshot-*` folder. Review the files before posting.
+
+## Linux Commands
+
+```bash
+uname -a
+cat /etc/os-release
+lspci -nn | grep -Ei 'intel|display|vga|3d'
+lsmod | grep -Ei 'xe|i915'
+xpu-smi discovery
+xpu-smi stats -d 0
+ze_info
+clinfo
+python - <<'PY'
+import torch
+print(torch.__version__)
+print(hasattr(torch, "xpu"))
+print(torch.xpu.device_count() if hasattr(torch, "xpu") else "no torch.xpu")
+PY
+```
+
+## Windows Commands
+
+```powershell
+Get-ComputerInfo | Select-Object OsName, OsVersion, WindowsVersion
+Get-PnpDevice -Class Display
+Get-CimInstance Win32_VideoController | Select-Object Name, DriverVersion, AdapterRAM
+xpu-smi discovery
+python -c "import torch; print(torch.__version__); print(hasattr(torch,'xpu')); print(torch.xpu.device_count() if hasattr(torch,'xpu') else 'no torch.xpu')"
+```
+
+## PCIe Notes
+
+On some Arc Pro B-series systems, bridge topology can make one reporting path look slower than the slot-facing link. Include both `lspci -vv` and `xpu-smi` output when asking about PCIe speed.
+
+## What Not To Do First
+
+- do not change five environment variables at once
+- do not benchmark before confirming device visibility
+- do not post screenshots only when text logs are available
+- do not assume a CUDA guide maps directly to XPU

--- a/docs/wiki/Docker-and-Containers.md
+++ b/docs/wiki/Docker-and-Containers.md
@@ -1,0 +1,57 @@
+# Docker And Containers
+
+Container support is a major goal for this community, but Intel XPU containers are sensitive to host driver/runtime compatibility.
+
+## Current Rule
+
+Do not publish a "works everywhere" Dockerfile until it has been tested on at least one real system and includes host requirements.
+
+## What A Good Container Guide Needs
+
+- host OS and kernel
+- host driver packages
+- Level Zero and device node requirements
+- container runtime version
+- Docker or Podman command
+- required device mounts
+- group permissions
+- image digest or Dockerfile commit
+- smoke test
+- known failures
+
+## Starter Topics
+
+- XPU device pass-through
+- Level Zero visibility inside containers
+- OpenCL visibility inside containers
+- PyTorch XPU smoke test
+- OpenVINO smoke test
+- vLLM XPU smoke test
+- llama.cpp SYCL build container
+
+## Draft Run Checklist
+
+Inside a container, verify:
+
+```bash
+ls -l /dev/dri || true
+ls -l /dev/accel || true
+ze_info || true
+clinfo || true
+python - <<'PY'
+import torch
+print(torch.__version__)
+print(hasattr(torch, "xpu"))
+print(torch.xpu.device_count() if hasattr(torch, "xpu") else "no torch.xpu")
+PY
+```
+
+## Promotion Criteria
+
+A container recipe should move from draft to guide when:
+
+- a second person can run it
+- the image is pinned
+- the host requirements are explicit
+- it has a minimal smoke test
+- it says what it does not solve

--- a/docs/wiki/Drivers-and-Runtimes.md
+++ b/docs/wiki/Drivers-and-Runtimes.md
@@ -1,0 +1,94 @@
+# Drivers And Runtimes
+
+Intel XPU deployments have several layers. Document each layer when posting a result.
+
+## Hardware Layer
+
+- GPU SKU and count
+- PCIe generation and lane width
+- ReBAR / Above 4G decoding
+- IOMMU
+- Secure Boot
+- cooling and power limits
+
+## OS Driver Layer
+
+Use official Intel driver documentation first.
+
+Windows:
+
+- Intel Graphics Windows DCH driver page
+- Device Manager
+- Intel Arc Control, if used
+
+Linux:
+
+- Intel discrete GPU docs
+- kernel version
+- firmware packages
+- Level Zero loader and GPU plugin packages
+- OpenCL runtime packages
+- `xpu-smi`
+
+## Developer Runtime Layer
+
+Common components:
+
+- oneAPI Base Toolkit
+- DPC++/C++ compiler
+- Level Zero
+- OpenCL
+- oneCCL
+- Intel Extension for PyTorch
+- OpenVINO
+- OpenVINO GenAI
+
+## Framework Layer
+
+Track exact versions and commits:
+
+- vLLM
+- llama.cpp
+- OpenVINO
+- PyTorch
+- Intel Extension for PyTorch
+- transformers
+- optimum-intel
+- oneDNN
+- llm-scaler or other extension libraries
+
+## Version Reporting Checklist
+
+Include these when asking for help:
+
+```text
+OS:
+Kernel:
+GPU:
+GPU count:
+Driver packages:
+xpu-smi version:
+Level Zero loader:
+Level Zero GPU plugin:
+OpenCL runtime:
+oneAPI version:
+PyTorch version:
+Intel Extension for PyTorch version:
+OpenVINO version:
+Framework:
+Framework commit:
+Model:
+Command:
+```
+
+## Known Pattern
+
+If a framework cannot see the GPU, test lower layers first. For example:
+
+1. OS can see PCIe device
+2. Level Zero can enumerate GPU
+3. OpenCL can enumerate GPU
+4. PyTorch/OpenVINO can enumerate GPU
+5. vLLM/llama.cpp can use the GPU
+
+The failing layer is usually more useful than the final error message alone.

--- a/docs/wiki/Getting-Started.md
+++ b/docs/wiki/Getting-Started.md
@@ -1,0 +1,66 @@
+# Getting Started
+
+This is the recommended first path for a new Intel XPU system.
+
+## 1. Inventory The System
+
+Before changing drivers or installing frameworks, collect:
+
+- GPU model and count
+- motherboard, CPU, RAM, power supply, and risers
+- operating system and kernel
+- BIOS settings for Above 4G decoding, ReBAR, IOMMU, PCIe speed, and Secure Boot
+- current driver packages
+- visible XPU devices from Level Zero, OpenCL, PyTorch, OpenVINO, and framework tools
+
+Use:
+
+- Linux: [`scripts/collect_xpu_snapshot.sh`](../../scripts/collect_xpu_snapshot.sh)
+- Windows: [`scripts/collect_xpu_snapshot.ps1`](../../scripts/collect_xpu_snapshot.ps1)
+
+These scripts are read-only except for writing a local snapshot folder.
+
+## 2. Install Official Drivers First
+
+Start from the official driver path for your OS.
+
+- Windows: Intel Graphics Windows DCH drivers
+- Linux: Intel GPU Linux documentation for your distro and kernel
+
+Do not mix random package repos until you have a known-good baseline.
+
+## 3. Verify Device Visibility
+
+A useful baseline sees the GPUs through several layers:
+
+- `lspci` or Device Manager
+- `xpu-smi` if available
+- Level Zero tools such as `ze_info`
+- OpenCL tools such as `clinfo`
+- PyTorch XPU
+- OpenVINO device query
+- the target framework, such as vLLM or llama.cpp
+
+If one layer sees the GPU and another does not, post both outputs.
+
+## 4. Pick A First Workload
+
+Choose a small, known workload first:
+
+- OpenVINO model device query or sample
+- PyTorch XPU tensor smoke test
+- llama.cpp SYCL small model smoke test
+- vLLM XPU smoke test with a model that fits comfortably
+
+Do not start with a huge multi-GPU model and driver tuning all at once.
+
+## 5. Record The Baseline
+
+Post the baseline in Discussions:
+
+- snapshot script output
+- installed driver/runtime versions
+- exact command
+- pass/fail
+- benchmark numbers if any
+- what you want to improve next

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,0 +1,32 @@
+# Home
+
+Welcome to the Unofficial Intel XPU Community wiki.
+
+This wiki is for practical Intel XPU work: Arc Pro B70 and other Intel GPUs, drivers, oneAPI, OpenVINO, PyTorch XPU, vLLM, llama.cpp, SYCL, Level Zero, Docker, benchmarks, and deployment notes.
+
+## Pages
+
+- [Getting Started](Getting-Started.md)
+- [Two B70 Use Cases](Two-B70-Use-Cases.md)
+- [Drivers And Runtimes](Drivers-and-Runtimes.md)
+- [Diagnostics](Diagnostics.md)
+- [Benchmarks And Results](Benchmarks-and-Results.md)
+- [Docker And Containers](Docker-and-Containers.md)
+- [Research Pipeline](Research-Pipeline.md)
+
+## What To Post In Discussions
+
+- setup help with hardware/software details
+- benchmark results with exact commands
+- guides that worked on your machine
+- patches and build notes
+- research links and release notes
+- negative results that keep others from wasting time
+
+## Stable Versus Experimental
+
+Use this wiki for repeatable community material. Use the lab repo for raw research:
+
+https://github.com/steveseguin/b70-optimization-lab
+
+When a lab result becomes reproducible, promote the guide, commands, patches, and benchmark metadata here.

--- a/docs/wiki/Research-Pipeline.md
+++ b/docs/wiki/Research-Pipeline.md
@@ -1,0 +1,60 @@
+# Research Pipeline
+
+The community repo should stay useful for deployment. The lab repo can stay fast and messy.
+
+## Roles
+
+### b70-optimization-lab
+
+Use for:
+
+- daily AI-assisted research updates
+- raw benchmark payloads
+- local patch artifacts
+- experiments that may fail
+- LocalMaxxing payloads and responses
+- detailed optimization diaries
+
+Repo: https://github.com/steveseguin/b70-optimization-lab
+
+### Unofficial-Intel-XPU-Community
+
+Use for:
+
+- setup guides
+- Docker guides
+- troubleshooting pages
+- curated benchmark results
+- patch summaries
+- discussion templates
+- wiki pages
+
+## Promotion Checklist
+
+Before moving a lab result here:
+
+- Is the result still current?
+- Is it reproducible by someone else?
+- Are commands included?
+- Are versions included?
+- Is the patch linked?
+- Is correctness or quality validated?
+- Is the status clear?
+- Are secrets and private paths removed?
+
+## Suggested Workflow
+
+1. AI agent runs research in `b70-optimization-lab`.
+2. AI agent opens a draft "promotion candidate" issue or PR here.
+3. Human reviews the risk and clarity.
+4. Community reproduces or challenges it.
+5. The guide moves into the wiki or docs with status labels.
+
+## Stable Output Types
+
+- `docs/wiki/*` for GitHub wiki import pages
+- `docs/guides/*` for longer guides
+- `templates/*` for repeatable submissions
+- `schemas/*` for structured benchmark data
+- `scripts/*` for read-only diagnostics and safe helpers
+- `docker/*` for tested container recipes

--- a/docs/wiki/Two-B70-Use-Cases.md
+++ b/docs/wiki/Two-B70-Use-Cases.md
@@ -1,0 +1,72 @@
+# Two B70 Use Cases
+
+Two Intel Arc Pro B70 cards provide a lot of local compute and 32 GB of VRAM per card, but they are not automatically one 64 GB GPU. Multi-GPU behavior depends on the framework and communication path.
+
+## Best First Use Cases
+
+### 1. Two Independent GPU Services
+
+This is usually the most reliable setup.
+
+Examples:
+
+- one model server per GPU
+- one production server and one experiment server
+- one LLM and one embedding server
+- one LLM and one video, vision, Whisper, or OpenVINO pipeline
+
+Benefits:
+
+- easier debugging
+- fewer multi-GPU communication failures
+- clear resource isolation
+- no tensor-parallel correctness assumptions
+
+### 2. Tensor Parallel Inference
+
+Use this when the framework supports XPU communication for your model.
+
+Candidate paths:
+
+- vLLM XPU backend
+- PyTorch XPU with oneCCL/XCCL
+- llama.cpp SYCL tensor split
+- OpenVINO or OpenVINO GenAI paths that support the target model
+
+What to measure:
+
+- does it load
+- does it generate correct output
+- is throughput better than one GPU
+- does longer context still fit
+- do repeat runs stay stable
+
+### 3. Capacity Split
+
+For models that barely fit on one card, a second GPU may help by splitting layers, pipeline stages, or services. Expect lower scaling than pure compute workloads.
+
+### 4. Development And Benchmark Lab
+
+Two cards are excellent for controlled comparisons:
+
+- driver A/B tests
+- framework version comparisons
+- one GPU as stable baseline, one GPU as experimental target
+- patch validation
+- thermal and power comparison
+
+## What Is Less Certain
+
+- transparent 64 GB memory pooling
+- automatic multi-GPU scaling
+- training large models without framework-specific work
+- assuming CUDA-oriented tuning maps directly to XPU
+
+## What To Post When Asking For Advice
+
+- motherboard and slot layout
+- CPU and RAM
+- power supply and connector layout
+- OS, kernel, driver version
+- intended models and quantization
+- whether you care more about max throughput, reliability, context length, or experimentation

--- a/schemas/benchmark-result.schema.json
+++ b/schemas/benchmark-result.schema.json
@@ -1,0 +1,107 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/steveseguin/Unofficial-Intel-XPU-Community/schemas/benchmark-result.schema.json",
+  "title": "Intel XPU Benchmark Result",
+  "type": "object",
+  "required": [
+    "date",
+    "status",
+    "hardware",
+    "software",
+    "model",
+    "workload",
+    "command",
+    "results"
+  ],
+  "properties": {
+    "date": {
+      "type": "string",
+      "format": "date"
+    },
+    "status": {
+      "type": "string",
+      "enum": ["stable", "draft", "experimental", "negative", "suspect", "rumor"]
+    },
+    "hardware": {
+      "type": "object",
+      "required": ["gpus"],
+      "properties": {
+        "gpus": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["model", "count"],
+            "properties": {
+              "model": { "type": "string" },
+              "count": { "type": "integer", "minimum": 1 },
+              "memory_gb_each": { "type": "number" }
+            }
+          }
+        },
+        "cpu": { "type": "string" },
+        "motherboard": { "type": "string" },
+        "ram_gb": { "type": "number" },
+        "pcie_notes": { "type": "string" }
+      }
+    },
+    "software": {
+      "type": "object",
+      "properties": {
+        "os": { "type": "string" },
+        "kernel": { "type": "string" },
+        "driver": { "type": "string" },
+        "xpu_smi": { "type": "string" },
+        "oneapi": { "type": "string" },
+        "framework": { "type": "string" },
+        "framework_commit": { "type": "string" },
+        "python": { "type": "string" }
+      }
+    },
+    "model": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" },
+        "source": { "type": "string" },
+        "quantization": { "type": "string" },
+        "context_length": { "type": "integer" }
+      }
+    },
+    "workload": {
+      "type": "object",
+      "properties": {
+        "prompt_tokens": { "type": "integer" },
+        "output_tokens": { "type": "integer" },
+        "batch_size": { "type": "integer" },
+        "concurrency": { "type": "integer" }
+      }
+    },
+    "command": {
+      "type": "string"
+    },
+    "environment": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "results": {
+      "type": "object",
+      "properties": {
+        "output_tokens_per_second": { "type": "number" },
+        "total_tokens_per_second": { "type": "number" },
+        "latency_ms": { "type": "number" },
+        "raw_output": { "type": "string" }
+      }
+    },
+    "validation": {
+      "type": "string"
+    },
+    "links": {
+      "type": "array",
+      "items": { "type": "string", "format": "uri" }
+    },
+    "notes": {
+      "type": "string"
+    }
+  }
+}

--- a/scripts/collect_xpu_snapshot.ps1
+++ b/scripts/collect_xpu_snapshot.ps1
@@ -1,0 +1,38 @@
+param(
+  [string]$OutDir = "xpu-snapshot-$(Get-Date -Format yyyyMMdd-HHmmss)"
+)
+
+New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
+
+function Run-Cmd {
+  param(
+    [string]$Name,
+    [scriptblock]$Command
+  )
+  $Path = Join-Path $OutDir "$Name.txt"
+  try {
+    & $Command *>&1 | Out-File -FilePath $Path -Encoding utf8
+  } catch {
+    $_ | Out-File -FilePath $Path -Encoding utf8
+  }
+}
+
+Run-Cmd "computer-info" { Get-ComputerInfo | Select-Object OsName, OsVersion, WindowsVersion, CsProcessors, CsTotalPhysicalMemory }
+Run-Cmd "display-devices" { Get-PnpDevice -Class Display }
+Run-Cmd "video-controller" { Get-CimInstance Win32_VideoController | Select-Object Name, DriverVersion, AdapterRAM, PNPDeviceID }
+Run-Cmd "xpu-smi-discovery" { xpu-smi discovery }
+Run-Cmd "xpu-smi-topology" { xpu-smi topology -m }
+Run-Cmd "python-version" { python --version }
+Run-Cmd "pip-freeze" { python -m pip freeze }
+Run-Cmd "torch-xpu" { python -c "import torch; print('torch', torch.__version__); print('has_xpu', hasattr(torch,'xpu')); print('xpu_count', torch.xpu.device_count() if hasattr(torch,'xpu') else 'n/a')" }
+Run-Cmd "openvino-devices" { python -c "import openvino as ov; print(ov.__version__); print(ov.Core().available_devices)" }
+Run-Cmd "docker-version" { docker --version }
+
+@"
+Intel XPU snapshot created at $(Get-Date -Format o)
+
+Review files before sharing publicly.
+Remove usernames, private paths, model names, hostnames, IPs, tokens, and any data you do not want public.
+"@ | Out-File -FilePath (Join-Path $OutDir "README.txt") -Encoding utf8
+
+Write-Host "Wrote $OutDir"

--- a/scripts/collect_xpu_snapshot.sh
+++ b/scripts/collect_xpu_snapshot.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -u
+
+OUT_DIR="${1:-xpu-snapshot-$(date +%Y%m%d-%H%M%S)}"
+mkdir -p "$OUT_DIR"
+
+run() {
+  local name="$1"
+  shift
+  {
+    echo "$ $*"
+    "$@"
+  } > "$OUT_DIR/$name.txt" 2>&1 || true
+}
+
+run_shell() {
+  local name="$1"
+  shift
+  {
+    echo "$ $*"
+    sh -c "$*"
+  } > "$OUT_DIR/$name.txt" 2>&1 || true
+}
+
+run uname uname -a
+run os-release cat /etc/os-release
+run lspci lspci -nn
+run_shell lspci-display "lspci -nn | grep -Ei 'intel|display|vga|3d'"
+run lsmod lsmod
+run_shell lsmod-gpu "lsmod | grep -Ei 'xe|i915|drm'"
+run xpu-smi-discovery xpu-smi discovery
+run xpu-smi-topology xpu-smi topology -m
+run ze-info ze_info
+run clinfo clinfo
+run python-version python3 --version
+run pip-freeze python3 -m pip freeze
+run torch-xpu python3 -c 'import torch; print("torch", torch.__version__); print("has_xpu", hasattr(torch, "xpu")); print("xpu_count", torch.xpu.device_count() if hasattr(torch, "xpu") else "n/a")'
+run openvino-devices python3 -c 'import openvino as ov; print(ov.__version__); print(ov.Core().available_devices)'
+run docker-version docker --version
+run podman-version podman --version
+
+cat > "$OUT_DIR/README.txt" <<EOF
+Intel XPU snapshot created at $(date -Is)
+
+Review files before sharing publicly.
+Remove usernames, private paths, model names, hostnames, IPs, tokens, and any data you do not want public.
+EOF
+
+echo "Wrote $OUT_DIR"

--- a/templates/benchmark-result.md
+++ b/templates/benchmark-result.md
@@ -1,0 +1,68 @@
+# Benchmark Result
+
+## Status
+
+- Status: stable / draft / experimental / negative / suspect
+- Date:
+- Reporter:
+
+## Hardware
+
+- GPU model and count:
+- CPU:
+- Motherboard:
+- RAM:
+- Storage:
+- PSU:
+- PCIe layout:
+- Cooling/power notes:
+
+## Software
+
+- OS:
+- Kernel/build:
+- Driver:
+- xpu-smi:
+- Level Zero:
+- OpenCL:
+- oneAPI:
+- PyTorch / OpenVINO / framework:
+- Framework commit or package:
+
+## Model
+
+- Model:
+- Source:
+- Quantization:
+- Context length:
+
+## Command
+
+```bash
+
+```
+
+## Environment Variables
+
+```bash
+
+```
+
+## Result
+
+- Prompt tokens:
+- Output tokens:
+- Batch/concurrency:
+- Output tokens/s:
+- Total tokens/s:
+- Latency:
+- Run count:
+- Cold or warm:
+
+## Validation
+
+Describe correctness or quality checks.
+
+## Notes
+
+What should someone else know before trying to reproduce this?


### PR DESCRIPTION
## Summary

This sets up the public community foundation for the Unofficial Intel XPU Community repo.

Included:

- README rewrite with clear positioning, start-here links, two-B70 guidance, and the relationship to `b70-optimization-lab`
- Community and contribution docs
- import-ready GitHub Wiki pages under `docs/wiki/`
- GitHub Discussion category forms for setup help, benchmarks/results, guides/patches, research links, and show-and-tell
- Issue template routing that pushes support/questions into Discussions
- benchmark result template and JSON schema
- read-only Linux and Windows XPU snapshot scripts
- current Intel XPU/B70 research snapshot with official Intel, GitHub, PyTorch, OpenVINO, and related source links
- guide for GitHub Wiki/Discussions setup, including the first-page wiki initialization caveat
- lab-to-deployment roadmap for promoting `b70-optimization-lab` findings into reproducible guides, Docker recipes, patches, and benchmark records

## Notes

The existing `b70-optimization-lab` repo is positioned as the fast-moving research feed. This repo is positioned as the stable place for reproducible setup guides, Docker recipes, patches, benchmarks, and promoted results.

I also attempted to initialize the actual GitHub Wiki git remote. The repository setting reports `has_wiki=true`, but direct clone/push to `Unofficial-Intel-XPU-Community.wiki.git` currently returns `Repository not found`, so the PR includes an explicit guide for initializing the first wiki page through the GitHub UI and then pushing these pages.

## Validation

- `git diff --check`
- parsed all `.github/**/*.yml` files with PyYAML
- parsed `schemas/benchmark-result.schema.json` with Python JSON parser